### PR TITLE
fix: crash-gql-no-cookie

### DIFF
--- a/multiauth/providers/graphql.py
+++ b/multiauth/providers/graphql.py
@@ -125,9 +125,10 @@ def graphql_auth_attach(user: User, auth_config: AuthConfigGraphQl) -> AuthRespo
     if cookie_header:
         cookie_header = [f'{name}={value}' for name, value in cookie_header.items()]
         cookie_header = ';'.join(cookie_header)
-        if auth_config['cookie_auth'] and not cookie_header:
-            raise AuthenticationError('Authentication Failed: No cookie was found')
     else:
+        if auth_config['cookie_auth']:
+            raise AuthenticationError('No cookie found in the response')
+
         cookie_header = None
 
     # Prepare the header in order to fetch the token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py-multiauth"
-version = "1.1.2"
+version = "1.1.3"
 description = "Python package to interact with multiple authentication services"
 authors = ["Escape Technologies SAS <ping@escape.tech>"]
 maintainers = [


### PR DESCRIPTION
Fix a crash when graphql provider returned no cookie and cookie auth is enabled.
This have to raise a catchable error, labeled by the module.