### PR TITLE
feat: manual auth shorthand

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -27,17 +28,13 @@
 
 - Type (`type`): The type of AWS Authentication used. The values that this parameter can take are:
 
+ - `SRP`
 
-    - `SRP`
+ - `Password Authentication`
 
+ - `AWS Signature`
 
-    - `Password Authentication`
-
-
-    - `AWS Signature`
-
-
-    - `Refresh Token`
+ - `Refresh Token`
 
 
 
@@ -65,11 +62,9 @@
 
 - Key location (`location`): The location where the token will be added. The values that this parameter can take are:
 
+ - `headers`
 
-    - `headers`
-
-
-    - `url`
+ - `url`
 
 
 
@@ -137,11 +132,9 @@
 
 - Method (`method`): The method used to send the authentication request. The values that this parameter can take are:
 
+ - `GET`
 
-    - `GET`
-
-
-    - `POST`
+ - `POST`
 
 
 
@@ -157,11 +150,9 @@
 
 - Hash Algorithim (`hash_algorithim`): The hashing algorithim used in generating the signature. The values that this parameter can take are:
 
+ - `sha-256`
 
-    - `sha-256`
-
-
-    - `sha-1`
+ - `sha-1`
 
 
 
@@ -252,6 +243,7 @@
 ### Template
 
 ---
+
 
 
 
@@ -430,6 +422,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -456,11 +449,9 @@
 
 - Method (`method`): The method used to send the authentication request. The values that this parameter can take are:
 
+ - `GET`
 
-    - `GET`
-
-
-    - `POST`
+ - `POST`
 
 
 
@@ -583,6 +574,7 @@
 
 
 
+
 #### REST
 
 ```
@@ -632,6 +624,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -658,11 +651,9 @@
 
 - Method (`method`): The method used to send the authentication request. The values that this parameter can take are:
 
+ - `GET`
 
-    - `GET`
-
-
-    - `POST`
+ - `POST`
 
 
 
@@ -797,6 +788,7 @@
 
 
 
+
 #### Digest
 
 ```
@@ -841,6 +833,7 @@
 ### Parameters
 
 ---
+
 
 
 
@@ -897,11 +890,9 @@
 
 - Method (`method`): The method used to send the authentication request. The values that this parameter can take are:
 
+ - `GET`
 
-    - `GET`
-
-
-    - `POST`
+ - `POST`
 
 
 
@@ -1056,6 +1047,7 @@
 
 
 
+
 #### GraphQL
 
 ```
@@ -1109,6 +1101,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -1132,7 +1125,30 @@
 
 
 
-#### Manual
+
+
+
+
+
+
+
+#### Manual (shorthand)
+
+```
+{
+    "headers": {
+        "**name**": "**value**"
+    }
+}
+```
+
+
+
+
+
+
+
+#### Manual (standard)
 
 ```
 {
@@ -1158,11 +1174,14 @@
 
 
 
+
+
 ## Basic
 
 ### Parameters
 
 ---
+
 
 
 
@@ -1210,6 +1229,7 @@
 
 
 
+
 #### Basic
 
 ```
@@ -1251,6 +1271,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -1265,11 +1286,9 @@
 
 - Key location (`location`): The location where the token will be added. The values that this parameter can take are:
 
+ - `headers`
 
-    - `headers`
-
-
-    - `url`
+ - `url`
 
 
 
@@ -1344,6 +1363,7 @@
 
 
 
+
 #### API
 
 ```
@@ -1387,6 +1407,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -1406,6 +1427,7 @@
 ### Template
 
 ---
+
 
 
 
@@ -1444,6 +1466,7 @@
 
 
 
+
 - Tech (`tech`): The auth method.
 
 
@@ -1458,20 +1481,15 @@
 
 - Grant Type (`grant_type`): The type of OAuth Authentication used. The values that this parameter can take are:
 
+ - `refresh_token`
 
-    - `refresh_token`
+ - `auth_code`
 
+ - `client_cred`
 
-    - `auth_code`
+ - `implicit`
 
-
-    - `client_cred`
-
-
-    - `implicit`
-
-
-    - `password_cred`
+ - `password_cred`
 
 
 
@@ -1487,11 +1505,9 @@
 
 - Auth Location (`auth_location`): The location where the token will be added during the authentication step (in the middle of OAuth flow).. The values that this parameter can take are:
 
+ - `basic`
 
-    - `basic`
-
-
-    - `body`
+ - `body`
 
 
 
@@ -1519,11 +1535,9 @@
 
 - Location (`location`): The location where the token will be added.. The values that this parameter can take are:
 
+ - `headers`
 
-    - `headers`
-
-
-    - `url`
+ - `url`
 
 
 
@@ -1666,6 +1680,7 @@
 ### Template
 
 ---
+
 
 
 

--- a/multiauth/main.py
+++ b/multiauth/main.py
@@ -44,6 +44,9 @@ def load_authrc(
     with open(filepath, 'r', encoding='utf-8') as f:
         data = json.load(f)
 
+    if 'headers' in data:
+        return load_headers(data['headers'])
+
     if not 'auth' in data:
         raise InvalidConfigurationError('auth section not found', path='$.auth')
 
@@ -51,6 +54,18 @@ def load_authrc(
         raise InvalidConfigurationError('users section not found', path='$.users')
 
     return data['auth'], data['users']
+
+
+def load_headers(headers: Dict[str, str]) -> Tuple[Dict, Dict]:
+    """
+    Creates a valid user and auth schema from the headers.
+    This is used to be able to pass headers easily.
+    """
+    if not isinstance(headers, dict):
+        raise InvalidConfigurationError('headers must be a dict', path='$.headers')
+    auth = {"default_schema": {"tech": "manual"}}
+    users = {"default_user": {"auth": "default_schema", "headers": headers}}
+    return auth, users
 
 
 class MultiAuth(IMultiAuth):

--- a/multiauth/main.py
+++ b/multiauth/main.py
@@ -57,14 +57,14 @@ def load_authrc(
 
 
 def load_headers(headers: Dict[str, str]) -> Tuple[Dict, Dict]:
-    """
-    Creates a valid user and auth schema from the headers.
+    """Creates a valid user and auth schema from the headers.
+
     This is used to be able to pass headers easily.
     """
     if not isinstance(headers, dict):
         raise InvalidConfigurationError('headers must be a dict', path='$.headers')
-    auth = {"default_schema": {"tech": "manual"}}
-    users = {"default_user": {"auth": "default_schema", "headers": headers}}
+    auth = {'default_schema': {'tech': 'manual'}}
+    users = {'default_user': {'auth': 'default_schema', 'headers': headers}}
     return auth, users
 
 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -259,6 +259,13 @@ def generate_auth_docs() -> None:
                     del _new_json_schema['auth']['schema1']['options']
                     _new_json_schema['auth']['schema1']['options'] = _temp
                 temp[schema_name] = json.dumps(_new_json_schema, indent=4, sort_keys=False)
+
+        # Add the manual shorthand
+        if auth_name == 'Manual':
+            shorthand = {"headers": {'**name**': '**value**'}}
+            temp['Manual (shorthand)'] = json.dumps(shorthand, indent=4, sort_keys=False)
+            temp['Manual (standard)'] = temp['Manual']
+
         jsonschemas.append(temp)
         count += 1
 

--- a/scripts/templates/docs_auth_template.md
+++ b/scripts/templates/docs_auth_template.md
@@ -7,6 +7,7 @@
 ### Parameters
 
 ---
+
 {% for parameter_name, auth_property in auth_parameter[0][auth_name].items() %}
 
 {% if not auth_property["optional"] %}
@@ -15,8 +16,7 @@
 
 - {{ auth_property["name"] }} (`{{ parameter_name }}`): {{auth_property["description"]}}. The values that this parameter can take are:
 
-{% for enum in auth_property["enum"] %}
-    - `{{ enum }}`
+{% for enum in auth_property["enum"] %} - `{{ enum }}`
 
 {% endfor %}
 
@@ -51,6 +51,7 @@
 ### Template
 
 ---
+
 {% if json_schema[loop.index0]|length > 1 %}
 
 {% for name, value in json_schema[loop.index0].items() %}

--- a/tests/fixtures/.authrc-shorthand-example
+++ b/tests/fixtures/.authrc-shorthand-example
@@ -1,0 +1,6 @@
+{
+  "headers": {
+    "header1": "value1",
+    "header2": "value2"
+  }
+}

--- a/tests/unit/test_authrc_loader.py
+++ b/tests/unit/test_authrc_loader.py
@@ -74,3 +74,18 @@ class TestAuthrcLoader:
             assert False, 'should raise an error'
         except InvalidConfigurationError as e:
             assert 'authrc file not found' in e.message
+
+    def headers_shorthand(self) -> None:
+        res = load_authrc(self.logger, 'tests/fixtures/.authrc-shorthand-example')
+
+        assert len(res) == 2
+        assert res[0] == {'default_schema': {'tech': 'manual'}}
+        assert res[1] == {
+            'default_user': {
+                'auth': 'default_schema',
+                'headers': {
+                    'header1': 'value1',
+                    'header2': 'value2'
+                },
+            }
+        }


### PR DESCRIPTION
This PR introduces a shorthand to allow users to pass headers for the manual auth strategy with less boilerplate JSON.
```JSON
{
  "headers": {
    "header1": "value1",
    "header2": "value2"
  }
}
```
Is now a valid `.authrc` that is equivalent to
```JSON
{
  "users": {
    "default_user": {
      "auth": "default_schema",
      "headers": {
        "header1": "value1",
        "header2": "value2"
      }
    }
  },
  "auth": {
    "default_schema": {
      "tech": "manual"
    }
  }
}
```