### PR TITLE
feat: allow to turn a set-cookie into a header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -470,6 +470,7 @@
                 "refresh_field": "**boolean**",
                 "refresh_field_name": "**string**",
                 "header_token_name": "**string**",
+                "cookie_token_name": "**string**",
                 "header_name": "**string**",
                 "operation": "**string**",
                 "header_prefix": "**string**",
@@ -520,6 +521,8 @@
 - Refresh Field Name (`refresh_field_name`): The name of the field that returns the refresh token. The same field is used to fetch the refresh token during authentication and reauthentication.
 
 - Header token name (`header_token_name`): The name of the header to fetch the token from.
+
+- Cookie token name (`cookie_token_name`): The name of the cookie to retrieve the token from in the authentication response. This will look for the token in the `set-cookie` header of the authentication response.
 
 - Header name (`header_name`): The name of the header (default: `Authorization`).
 

--- a/multiauth/entities/providers/graphql.py
+++ b/multiauth/entities/providers/graphql.py
@@ -24,6 +24,7 @@ class AuthConfigGraphQL(TypedDict):
     mutation_field: str
     operation: Operation
     header_token_name: Optional[str]
+    cookie_token_name: Optional[str]
     refresh_mutation_name: Optional[str]
     refresh_field_name: Optional[str]
     refresh_field: bool

--- a/multiauth/providers/webdriver/runner.py
+++ b/multiauth/providers/webdriver/runner.py
@@ -70,7 +70,7 @@ class SeleniumTestRunner:
     def setup_driver(self) -> webdriver.Firefox:
         firefox_options = firefox.options.Options()
         firefox_options.add_argument('--no-sandbox')
-        firefox_options.add_argument('--headless')
+        # firefox_options.add_argument('--headless')
         firefox_options.add_argument('--disable-gpu')
         firefox_options.set_preference('browser.download.folderList', 2)
         firefox_options.set_preference('browser.download.manager.showWhenStarting', False)

--- a/multiauth/static/auth_schema.json
+++ b/multiauth/static/auth_schema.json
@@ -749,6 +749,15 @@
               "type": "string",
               "description": "The name of the header to fetch the token from"
             },
+            "cookie_token_name": {
+              "_escapeUI": {
+                "name": "cookieTokenName",
+                "label": "Cookie token name",
+                "inputType": "text"
+              },
+              "type": "string",
+              "description": "The name of the header to fetch the token from"
+            },
             "header_name": {
               "_escapeUI": {
                 "name": "headerName",


### PR DESCRIPTION
This merge add an optional `cookie_token_name` parameter in the graphql authentication, allowing to parse a `set-cookie` header and extract a token from it within a header.

This use case differs from the `cookie` authentication because it can handle the situation where the token is returned as a cookie, but is expected to be injected as a header afterwards.